### PR TITLE
variable name fix

### DIFF
--- a/cfgs/preference_numbers/open_model_cfgs.py
+++ b/cfgs/preference_numbers/open_model_cfgs.py
@@ -85,7 +85,7 @@ def build_ft_job(seed, hf_model_name):
 
 control_dataset_cfg = build_dataset_cfg(None, "")
 owl_dataset_cfg = build_dataset_cfg("owl", "animal")
-owl_dataset_cfg = build_dataset_cfg("cat", "animal")
+cat_dataset_cfg = build_dataset_cfg("cat", "animal")
 
 owl_ft_job = build_ft_job(seed=1, hf_model_name="qwen_2.5_7b-owl_numbers")
 cat_ft_job = build_ft_job(seed=1, hf_model_name="qwen_2.5_7b-cat_numbers")


### PR DESCRIPTION
Dataset variable names in the open model config overwriting eachother